### PR TITLE
MoveWindowToRelativeDesktopNum for left/right movement

### DIFF
--- a/_VD.ahk
+++ b/_VD.ahk
@@ -246,6 +246,16 @@ class VD {
         this._MoveView_to_IVirtualDesktop(thePView, IVirtualDesktop)
     }
 
+    MoveWindowToRelativeDesktopNum(wintitle,relativeNum)
+    {
+        targetNum:=this.getDesktopNumOfWindow(wintitle) + relativeNum
+        targetNum:=Mod(targetNum, this.getCount())
+        while (targetNum <= 0) {
+            targetNum:=targetNum + this.getCount()
+        }
+        return this.MoveWindowToDesktopNum(wintitle, targetNum)
+    }
+
     MoveWindowToCurrentDesktop(wintitle,activateYourWindow:=true)
     {
         found:=this._getFirstValidWindow(wintitle)

--- a/_VD.ahk
+++ b/_VD.ahk
@@ -250,7 +250,7 @@ class VD {
     {
         targetNum:=this.getDesktopNumOfWindow(wintitle) + relativeNum
         targetNum:=Mod(targetNum, this.getCount())
-        while (targetNum <= 0) {
+        if (targetNum <= 0) {
             targetNum:=targetNum + this.getCount()
         }
         return this.MoveWindowToDesktopNum(wintitle, targetNum)


### PR DESCRIPTION
Add MoveWindowToRelativeDesktopNum for moving windows to the left or right using

```
VD.MoveWindowToRelativeDesktopNum("A", -1) ; move to left
VD.MoveWindowToRelativeDesktopNum("A", +1) ; move to right
```

I kept it generic and not with explicit left/right, such that someone could also implement skipping of sorts.

The indices wrap around on the first and last desktop. Thus, moving a window to the left on the first desktop sends it to the last and vice versa.