### PR TITLE
VD.ah2: check WinExist before WinGetMinMax

### DIFF
--- a/VD.ah2
+++ b/VD.ah2
@@ -549,6 +549,9 @@ class VD {
       return -1
     }
     theHwnd := found[1]
+    if (!WinExist("ahk_id " theHwnd)) {
+      Return
+    }
     OutputVar_MinMax := WinGetMinMax("ahk_id " theHwnd)
     if (!(OutputVar_MinMax == -1)) {
       WinActivate "ahk_id " theHwnd


### PR DESCRIPTION
On Windows 11, I'm getting some errors on WinGetMinMax that window doesn't exist, I think because we still get the hwnd from the old desktop which doesn't exist on the new desktop, maybe some form of race condition.

Adding the check for WinExist avoids the error, and it works as expected with the window under activated.

Thanks for the script/library!