### PR TITLE
VD.ah2: remove duplicate calls

### DIFF
--- a/VD.ah2
+++ b/VD.ah2
@@ -529,13 +529,11 @@ class VD {
   }
   static _MoveView_to_IVirtualDesktop(thePView, IVirtualDesktop) {
     DllCall(this.MoveViewToDesktop, "ptr", this.IVirtualDesktopManagerInternal.Ptr, "Ptr", thePView, "Ptr", IVirtualDesktop)
-    DllCall(this.MoveViewToDesktop, "ptr", this.IVirtualDesktopManagerInternal.Ptr, "Ptr", thePView, "Ptr", IVirtualDesktop)
     this._activateWindowUnder()
   }
   static _SwitchIVirtualDesktop(IVirtualDesktop) {
     WinActivate "ahk_class Shell_TrayWnd"
     WinWaitActive "ahk_class Shell_TrayWnd"
-    this._dll_SwitchDesktop(IVirtualDesktop)
     this._dll_SwitchDesktop(IVirtualDesktop)
     this._activateWindowUnder()
   }


### PR DESCRIPTION
Not sure why they're there, was it unreliable with just one?

Works fine with me on Windows 11 with a single call.