### PR TITLE
Updated to work with Win11 Dev 23606.

### DIFF
--- a/_VD.ahk
+++ b/_VD.ahk
@@ -69,8 +69,8 @@ class VD {
         else
         {
             ; Windows 11
-            IID_IVirtualDesktopManagerInternal_:="{B2F925B9-5A0F-4D2E-9F4D-2B1507593C10}" ;https://github.com/MScholtes/VirtualDesktop/blob/812c321e286b82a10f8050755c94d21c4b69812f/VirtualDesktop11.cs#L163-L185
-            IID_IVirtualDesktop_:="{536D3495-B208-4CC9-AE26-DE8111275BF8}" ;https://github.com/MScholtes/VirtualDesktop/blob/812c321e286b82a10f8050755c94d21c4b69812f/VirtualDesktop11.cs#L149-L150
+            IID_IVirtualDesktopManagerInternal_:="{4970BA3D-FD4E-4647-BEA3-D89076EF4B9C}" ;https://github.com/MScholtes/VirtualDesktop/blob/812c321e286b82a10f8050755c94d21c4b69812f/VirtualDesktop11.cs#L163-L185
+            IID_IVirtualDesktop_:="{3F07F4BE-B107-441A-AF0F-39D82529072C}" ;https://github.com/MScholtes/VirtualDesktop/blob/812c321e286b82a10f8050755c94d21c4b69812f/VirtualDesktop11.cs#L149-L150
             ;conditionally assign method to method
             this._dll_GetCurrentDesktop:=this._dll_GetCurrentDesktop_Win11
             this._dll_GetDesktops:=this._dll_GetDesktops_Win11
@@ -78,6 +78,7 @@ class VD {
             this._dll_GetName:=this._dll_GetName_Win11
             this.RegisterDesktopNotifications:=this.RegisterDesktopNotifications_Win11
         }
+
         ;----------------------
         this.IVirtualDesktopManager := ComObjCreate("{AA509086-5CA9-4C25-8F95-589D3C07B48A}", "{A5CD92FF-29BE-454C-8D04-D82879FB3F1B}")
         this.GetWindowDesktopId := this._vtable(this.IVirtualDesktopManager, 4)
@@ -113,14 +114,14 @@ class VD {
         } else {
             ;Windows 11 Insider build 22489 https://github.com/MScholtes/VirtualDesktop/blob/9f3872e1275408a0802bdbe46df499bb7645dc87/VirtualDesktop11Insider.cs#L163-L186
 
-            ; this.GetAllCurrentDesktops := this._vtable(this.IVirtualDesktopManagerInternal, 7) ; IObjectArray GetAllCurrentDesktops();
-            this.GetDesktops := this._vtable(this.IVirtualDesktopManagerInternal, 8) ; void GetDesktops(IntPtr hWndOrMon, out IObjectArray desktops);
-            ; this.GetAdjacentDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 9) ; int GetAdjacentDesktop(IVirtualDesktop from, int direction, out IVirtualDesktop desktop);
-            ; this.SwitchDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 10) ; void SwitchDesktop(IntPtr hWndOrMon, IVirtualDesktop desktop);
-            this.Ptr_CreateDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 11) ; IVirtualDesktop CreateDesktop(IntPtr hWndOrMon);
-            ; this.MoveDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 12) ; void MoveDesktop(IVirtualDesktop desktop, IntPtr hWndOrMon, int nIndex);
-            this.Ptr_RemoveDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 13) ; void RemoveDesktop(IVirtualDesktop desktop, IVirtualDesktop fallback);
-            this.FindDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 14) ; IVirtualDesktop FindDesktop(ref Guid desktopid);
+            ; this.GetAllCurrentDesktops := this._vtable(this.IVirtualDesktopManagerInternal, 6) ; IObjectArray GetAllCurrentDesktops();
+            this.GetDesktops := this._vtable(this.IVirtualDesktopManagerInternal, 7) ; void GetDesktops(IntPtr hWndOrMon, out IObjectArray desktops);
+            ; this.GetAdjacentDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 8) ; int GetAdjacentDesktop(IVirtualDesktop from, int direction, out IVirtualDesktop desktop);
+            ; this.SwitchDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 9) ; void SwitchDesktop(IntPtr hWndOrMon, IVirtualDesktop desktop);
+            this.Ptr_CreateDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 10) ; IVirtualDesktop CreateDesktop(IntPtr hWndOrMon);
+            ; this.MoveDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 11) ; void MoveDesktop(IVirtualDesktop desktop, IntPtr hWndOrMon, int nIndex);
+            this.Ptr_RemoveDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 12) ; void RemoveDesktop(IVirtualDesktop desktop, IVirtualDesktop fallback);
+            this.FindDesktop := this._vtable(this.IVirtualDesktopManagerInternal, 13) ; IVirtualDesktop FindDesktop(ref Guid desktopid);
         }
 
         ;https://github.com/MScholtes/VirtualDesktop/blob/812c321e286b82a10f8050755c94d21c4b69812f/VirtualDesktop.cs#L225-L234
@@ -168,7 +169,7 @@ class VD {
     }
     _dll_GetCurrentDesktop_Win11() {
         IVirtualDesktop_ofCurrentDesktop := 0
-        DllCall(this.GetCurrentDesktop, "UPtr", this.IVirtualDesktopManagerInternal, "Ptr", 0, "Ptr*", IVirtualDesktop_ofCurrentDesktop)
+        DllCall(this.GetCurrentDesktop, "UPtr", this.IVirtualDesktopManagerInternal, "Ptr*", IVirtualDesktop_ofCurrentDesktop)
         return IVirtualDesktop_ofCurrentDesktop
     }
     _dll_GetDesktops_Win10() {
@@ -178,7 +179,7 @@ class VD {
     }
     _dll_GetDesktops_Win11() {
         IObjectArray := 0
-        DllCall(this.GetDesktops, "UPtr", this.IVirtualDesktopManagerInternal, "Ptr", 0, "UPtr*", IObjectArray)
+        DllCall(this.GetDesktops, "UPtr", this.IVirtualDesktopManagerInternal, "Ptr*", IObjectArray)
         return IObjectArray
     }
     _dll_CreateDesktop_Win10() {
@@ -188,7 +189,7 @@ class VD {
     }
     _dll_CreateDesktop_Win11() {
         IVirtualDesktop_ofNewDesktop:=0
-        DllCall(this.Ptr_CreateDesktop, "UPtr", this.IVirtualDesktopManagerInternal, "Ptr", 0, "Ptr*", IVirtualDesktop_ofNewDesktop)
+        DllCall(this.Ptr_CreateDesktop, "UPtr", this.IVirtualDesktopManagerInternal, "Ptr*", IVirtualDesktop_ofNewDesktop)
         return IVirtualDesktop_ofNewDesktop
     }
     _dll_GetName_Win10(IVirtualDesktop) {
@@ -602,7 +603,7 @@ class VD {
         }
 
         str_IID_IUnknown:="{00000000-0000-0000-C000-000000000046}"
-        str_IID_IVirtualDesktopNotification:="{CD403E52-DEED-4C13-B437-B98380F2B1E8}"
+        str_IID_IVirtualDesktopNotification:="{B9E5E94D-233E-49AB-AF5C-2B4541C3AADE}"
 
         VarSetCapacity(someStr, 40*2)
         DllCall("Ole32\StringFromGUID2", "Ptr", riid, "Ptr",&someStr, "Ptr",40)


### PR DESCRIPTION
In the latest Win11 Dev release # 23606 the COM GUID changed as well as the methods in Win11 Dev were reverted back to maintain Win10 compatibility and the `_vtable` order was revered back to Win11 stable compatibility.

This PR addresses #61 

This isn't really a ready PR since it breaks backwards compatibility and doesn't add another `if` block for this differing Win11 version.  Though it seems the `if` block that sets the `_vtable` order can be consolidated to a single else to match stable Win11.  The methods for Win11 dev would need to be duplicated though and basically just point back at the Win10 methods.  I updated the IVirtualDesktopNotification GUID too even though I don't know what it does, but it was different.  I found the updated GUIDs from another project here:
https://github.com/itzjakm/VirtualDesktopAccessor/blob/22635.2915/src/interfaces.rs

But at least with this PR what's necessary is clear as well as the new GUIDs.  I haven't thoroughly tested all the functions, only what was necessary for my script which was: `VD.getCurrentDesktopNum()`, `VD.MoveWindowToDesktopNum(active,n)`, `VD.goToDesktopNum(n)`