### PR TITLE
Port Task Switcher3 example to AutoHotkey v2

### DIFF
--- a/other examples/Task Switcher3.ahk
+++ b/other examples/Task Switcher3.ahk
@@ -1,102 +1,100 @@
-#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
-#SingleInstance, force
-SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
-SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
-SetBatchLines, -1
-#KeyHistory 0
-ListLines Off
+#Requires AutoHotkey v2.0
+#SingleInstance Force
+SendMode "Input"
+SetWorkingDir A_ScriptDir
+A_KeyHistory := 0
+ListLines False
 
-SetWinDelay, -1
-SetControlDelay, -1
+SetWinDelay -1
+SetControlDelay -1
 
-#Include %A_LineFile%\..\..\VD.ahk
+#Include "..\VD.ah2"
 
-MenuItemTitleLength:=100
-OnMessage( 0x0006, "HandleMessage" ) ;to detect gui lose focus
-f1::
-arrayOfWindowsInfo:=[] ;to store {desktopNum:number, str:INFO}
+MenuItemTitleLength := 100
+OnMessage(0x0006, HandleMessage) ; to detect gui lose focus
 
-DetectHiddenWindows, on
-WinGet windows, List
-Loop %windows%
-{
-    id := windows%A_Index%
-    ahk_idId := "ahk_id " id
-    desktopOfWindow:=VD.getDesktopNumOfWindow(ahk_idId)
-    if (desktopOfWindow > -1)
-    {
-        WinGetTitle, OutputTitle, % ahk_idId
-        WinGet, OutputProcessPath, ProcessPath, % ahk_idId
+F1:: {
+    global myGui
+    arrayOfWindowsInfo := [] ; to store {desktopNum:number, str:INFO}
 
-        arrayOfWindowsInfo.Push({desktopNum:desktopOfWindow, title:OutputTitle, processPath:OutputProcessPath, hwnd:id})
+    DetectHiddenWindows True
+    windows := WinGetList()
+
+    for id in windows {
+        ahk_idId := "ahk_id " id
+        desktopOfWindow := VD.getDesktopNumOfWindow(ahk_idId)
+        if (desktopOfWindow > -1) {
+            OutputTitle := WinGetTitle(ahk_idId)
+            OutputProcessPath := WinGetProcessPath(ahk_idId)
+
+            arrayOfWindowsInfo.Push({desktopNum: desktopOfWindow, title: OutputTitle, processPath: OutputProcessPath, hwnd: id})
+        }
     }
-}
 
-arrayOfWindowsInfo:=sortArrByKey(arrayOfWindowsInfo,"desktopNum")
+    arrayOfWindowsInfo := sortArrByKey(arrayOfWindowsInfo, "desktopNum")
 
-ArrForMenuItemPos:=[]
+    ArrForMenuItemPos := []
 
-Gui, Destroy
-Gui, New, -0xC00000
+    if IsSet(myGui) && IsObject(myGui) {
+        myGui.Destroy()
+    }
+    myGui := Gui("+ToolWindow -Caption")
 
-guiWidth:=600
+    guiWidth := 600
 
-lastDesktopNum:=-1
-for k, v in arrayOfWindowsInfo {
+    lastDesktopNum := -1
+    for index, winInfo in arrayOfWindowsInfo {
+        if (!(winInfo.desktopNum == lastDesktopNum)) {
+            lastDesktopNum := winInfo.desktopNum
+            _name := VD.getNameFromDesktopNum(lastDesktopNum)
+            if (_name == "") {
+                _name := "Desktop " winInfo.desktopNum
+            }
 
-    if (!(v.desktopNum == lastDesktopNum)) {
-        lastDesktopNum:=v.desktopNum
-        _name:=VD.getNameFromDesktopNum(lastDesktopNum)
-        if (_name=="") {
-            _name:="Desktop " v.desktopNum
+            OMG := myGui.Add("Text", "x10", _name)
+            OMG.GetPos(&Xpos, &Ypos, &Width, &Height)
+            myGui.Add("Text", "x" (Xpos + Width + 3) " y" (Ypos - 5) " 0x00000005 h1 w" (guiWidth - (Xpos + Width)))
         }
 
-        Gui, Add, Text, % "x10 hwndOMG", % _name
-        ControlGetPos, Xpos, Ypos, Width, Height,, % "ahk_id " OMG
-        Gui, Add, Text, % "x+3 y+-5 0x00000005 h1 w" guiWidth - (Xpos + Width)
+        title := SubStr(winInfo.title, 1, MenuItemTitleLength)
+        myGui.Add("Text", "x20", title)
     }
+    DetectHiddenWindows False
 
-    title:=SubStr(v.title, 1, MenuItemTitleLength)
-    Gui, Add, Text, % "x20", % title
+    CoordMode "Menu", "Screen"
+    Xm := (0.4 * A_ScreenWidth)
+    Ym := (0.6 * A_ScreenHeight)
+    myGui.Show("X" Xm " Y" Ym)
 }
-DetectHiddenWindows, off
 
-CoordMode, Menu, Screen
-WinGetPos,,, Width, Height,
-Xm := (0.4*A_ScreenWidth)
-Ym := (0.6*A_ScreenHeight)
-; MouseGetPos, OutputVarX, OutputVarY
-Gui, Show, % "X" Xm " Y" Ym
+F3::ExitApp
 
-return
-
-HandleMessage( p_w, p_l, p_m, p_hw )
-{
-    global
-    ; ToolTip % p_w ", " p_l
-    if (p_w==0) {
-        Gui, Destroy
+HandleMessage(p_w, p_l, p_m, p_hw) {
+    global myGui
+    if (p_w == 0) {
+        if IsSet(myGui) && IsObject(myGui) {
+            myGui.Destroy()
+        }
     }
 }
 
-sortArrByKey(arr, key, sortType:="N") {
-    str:=""
-    for k,v in arr {
-        str.=v[key] "+" k "|"
+sortArrByKey(arr, key, sortType := "N") {
+    str := ""
+    for index, value in arr {
+        str .= value.%key% "+" index "|"
     }
-    length:=arr.Length()
-    Sort, str, % "D| " sortType
-    finalAr:=[]
-    finalAr.SetCapacity(length)
-    barPos:=1
-    loop %length% {
-        plusPos:=InStr(str, "+",, barPos)
-        barPos:=InStr(str, "|",, plusPos)
+    length := arr.Length
+    str := Sort(str, "D| " sortType)
+    finalAr := []
+    finalAr.Capacity := length
+    barPos := 1
 
-        num:=SubStr(str, plusPos + 1, barPos - plusPos - 1)
+    loop length {
+        plusPos := InStr(str, "+", , barPos)
+        barPos := InStr(str, "|", , plusPos)
+
+        num := SubStr(str, plusPos + 1, barPos - plusPos - 1)
         finalAr.Push(arr[num])
     }
     return finalAr
 }
-
-f3::Exitapp


### PR DESCRIPTION
Convert Task Switcher3.ahk from v1 to v2 syntax including:
- Update directives: #Requires v2.0, modernize #SingleInstance and SendMode
- Replace Gui v1 commands with v2 Gui() class methods
- Convert WinGet/WinGetTitle to WinGetList()/WinGetTitle()
- Update loop syntax from "Loop %var%" to "loop var"
- Modernize function definitions and message handlers
- Fix array property access using dot notation
- Update #Include path to VD.ah2

🤖 Generated with [Claude Code](https://claude.com/claude-code)